### PR TITLE
GitHub action trigger

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,22 +1,53 @@
 export const handler = async (event) => {
-    const webhookId = "webhookId";
-    const webhookToken ="webhookToken";
-    
-    try {
-      await fetch(
-        `https://discord.com/api/webhooks/${webhookId}/${webhookToken}`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            content: "📢 정기 배포 PR을 생성해주세요!",
-          }),
-        }
-      );
-      console.log("success");
-    } catch (error) {
-      console.error("error", error);
+  const webhookId = "your-discord-webhook-id";
+  const webhookToken = "your-discord-webhook-token";
+
+  // 해당 토큰은 themoment-team 조직에 접근할 수 있고, owner 권한이 있는 사람의 토큰이어야함
+  const githubToken = process.env.GITHUB_TOKEN;
+
+  const owner = "themoment-team";
+  const repo = "hellogsm-front-24";
+  const workflowFileName = "regular-deploy.yml";
+  const ref = "develop";
+
+  try {
+    await fetch(
+      `https://discord.com/api/webhooks/${webhookId}/${webhookToken}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          content: "📢 정기 배포 PR을 생성합니다!",
+        }),
+      }
+    );
+    console.log("디스코드 알림 전송 완료");
+
+    const githubRes = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${workflowFileName}/dispatches`,
+      {
+        method: "POST",
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${githubToken}`,
+          "X-GitHub-Api-Version": "2022-11-28",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          ref,
+        }),
+      }
+    );
+
+    if (githubRes.ok) {
+      console.log("github action실행 성공");
+    } else {
+      const errorText = await githubRes.text();
+      console.error("gitHub action 실행 실패:", errorText);
     }
-  };
+  } catch (error) {
+    console.error("error", error);
+  }
+};

--- a/index.mjs
+++ b/index.mjs
@@ -8,7 +8,7 @@ export const handler = async (event) => {
   const owner = "themoment-team";
   const repo = "hellogsm-front-24";
   const workflowFileName = "regular-deploy.yml";
-  const ref = "develop";
+  const ref = "main";
 
   try {
     await fetch(


### PR DESCRIPTION
프로젝트의 정기 베포 알림을 할때 정기 베포 pr을 만들면 좋을 것 같아서 만들어 수정해봤습니다

1. 변수설정
```mjs
 // 해당 토큰은 themoment-team 조직에 접근할 수 있고, owner 권한이 있는 사람의 토큰이어야함
  const githubToken = process.env.GITHUB_TOKEN;

  const owner = "themoment-team";
  const repo = "hellogsm-front-24";
  const workflowFileName = "regular-deploy.yml";
  const ref = "develop";
```

더모먼트 접근에 필요한 설정들

2. 디스코드 정기베포 알림
3. 원격 githubAction 요청
```mjs
const githubRes = await fetch(
  `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${workflowFileName}/dispatches`,
  {
    method: "POST",
    headers: {
      Accept: "application/vnd.github+json",
      Authorization: `Bearer ${githubToken}`,
      "X-GitHub-Api-Version": "2022-11-28",
      "Content-Type": "application/json",
    },
    body: JSON.stringify({
      ref,
    }),
  }
);
```
이런식으로 github api를 사용하면 원하는 workflows를 가동시킬 수 있는것 같습니다